### PR TITLE
split-pay Add AccountManagementService / transfer capability to SDK

### DIFF
--- a/source/Paysafe/AccountManagement/Transfer.php
+++ b/source/Paysafe/AccountManagement/Transfer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Paysafe\AccountManagement;
+
+class Transfer extends \Paysafe\JSONObject implements \Paysafe\Pageable {
+
+    public static function getPageableArrayKey() {
+        return "transfers";
+    }
+
+    protected static $fieldTypes = array(
+        'id' => 'string',
+        'amount' => 'int',
+        'detail' => 'string',
+        'dupCheck' => 'bool',
+        'linkedAccount' => 'string',
+        'merchantRefNum' => 'string',
+        'error' => '\Paysafe\Error',
+        'status' => array(
+            'RECEIVED',
+            'PENDING',
+            'PROCESSING',
+            'COMPLETED',
+            'FAILED',
+            'CANCELLED'
+        ),
+        'links' => 'array:\Paysafe\Link'
+    );
+
+    /**
+     *
+     * @param type $linkName
+     * @return \Paysafe\HostedPayment\Link
+     * @throws PaysafeException
+     */
+    public function getLink( $linkName ) {
+        if (!empty($this->link)) {
+            foreach ($this->link as $link) {
+                if ($link->rel == $linkName) {
+                    return $link;
+                }
+            }
+        }
+        throw new PaysafeException("Link $linkName not found in purchase.");
+    }
+}

--- a/source/Paysafe/AccountManagement/Transfer.php
+++ b/source/Paysafe/AccountManagement/Transfer.php
@@ -2,6 +2,22 @@
 
 namespace Paysafe\AccountManagement;
 
+use Paysafe\PaysafeException;
+
+/**
+ * Class Transfer
+ * @package Paysafe\AccountManagement
+ *
+ * @property string $id
+ * @property int $amount
+ * @property string $detail
+ * @property bool $dupCheck
+ * @property string $linkedAccount
+ * @property string $merchantRefNum
+ * @property \Paysafe\Error $error
+ * @property string $status
+ * @property \Paysafe\Link[] $links
+ */
 class Transfer extends \Paysafe\JSONObject implements \Paysafe\Pageable {
 
     public static function getPageableArrayKey() {
@@ -29,18 +45,18 @@ class Transfer extends \Paysafe\JSONObject implements \Paysafe\Pageable {
 
     /**
      *
-     * @param type $linkName
-     * @return \Paysafe\HostedPayment\Link
+     * @param string $linkName
+     * @return \Paysafe\Link
      * @throws PaysafeException
      */
     public function getLink( $linkName ) {
-        if (!empty($this->link)) {
-            foreach ($this->link as $link) {
+        if (!empty($this->links)) {
+            foreach ($this->links as $link) {
                 if ($link->rel == $linkName) {
                     return $link;
                 }
             }
         }
-        throw new PaysafeException("Link $linkName not found in purchase.");
+        throw new PaysafeException("Link $linkName not found in Transfer.");
     }
 }

--- a/source/Paysafe/AccountManagementService.php
+++ b/source/Paysafe/AccountManagementService.php
@@ -78,6 +78,11 @@ class AccountManagementService
         return new Transfer($response);
     }
 
+    /**
+     * Move funds from the linked account in the body of the request to the account identified in the API endpoint URI.
+     * @param \Paysafe\AccountManagement\Transfer $transfer
+     * @return \Paysafe\AccountManagement\Transfer
+     */
     public function transferCredit(Transfer $transfer)
     {
         $transfer->setRequiredFields(array(

--- a/source/Paysafe/AccountManagementService.php
+++ b/source/Paysafe/AccountManagementService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Paysafe;
+
+use Paysafe\AccountManagement\Transfer;
+
+class AccountManagementService
+{
+    /**
+     * @var PaysafeApiClient
+     */
+    private $client;
+
+    /**
+     * The uri for the card payment api.
+     * @var string
+     */
+    private $uri = "accountmanagement/v1";
+    private $debitPath = "/debits";
+    private $creditPath = "/credits";
+
+    /**
+     * Initialize the Account Management service.
+     *
+     * @param \Paysafe\PaysafeApiClient $client
+     */
+    public function __construct( PaysafeApiClient $client )
+    {
+        $this->client = $client;
+    }
+
+    public function transferDebit(Transfer $transfer)
+    {
+        $request = new Request(array(
+               'method' => Request::POST,
+               'uri' => $this->prepareURI($this->debitPath),
+               'body' => $transfer
+           ));
+
+        $response = $this->client->processRequest($request);
+
+        return new Transfer($response);
+    }
+
+    public function transferCredit(Transfer $transfer)
+    {
+        $request = new Request(array(
+               'method' => Request::POST,
+               'uri' => $this->prepareURI($this->creditPath),
+               'body' => $transfer
+           ));
+
+        $response = $this->client->processRequest($request);
+
+        return new Transfer($response);
+    }
+
+    private function prepareURI($path)
+    {
+        if (!$this->client->getAccount())
+        {
+            throw new PaysafeException('Missing or invalid account', 500);
+        }
+
+        return $this->uri . "/accounts/" . $this->client->getAccount() . $path;
+    }
+}

--- a/source/Paysafe/AccountManagementService.php
+++ b/source/Paysafe/AccountManagementService.php
@@ -7,7 +7,7 @@ use Paysafe\AccountManagement\Transfer;
 class AccountManagementService
 {
     /**
-     * @var PaysafeApiClient
+     * @var \Paysafe\PaysafeApiClient
      */
     private $client;
 
@@ -49,8 +49,24 @@ class AccountManagementService
         return ($response['status'] == 'READY');
     }
 
+    /**
+     * Move funds from the account identified in the API endpoint URI to the linked account in the body of the request
+     * @param \Paysafe\AccountManagement\Transfer $transfer
+     * @return \Paysafe\AccountManagement\Transfer
+     * @throws \Paysafe\PaysafeException
+     */
     public function transferDebit(Transfer $transfer)
     {
+        $transfer->setRequiredFields(array(
+            'amount',
+            'linkedAccount',
+            'merchantRefNum',
+        ));
+        $transfer->setOptionalFields(array(
+            'detail',
+            'dupCheck',
+        ));
+
         $request = new Request(array(
                'method' => Request::POST,
                'uri' => $this->prepareURI($this->debitPath),
@@ -64,6 +80,16 @@ class AccountManagementService
 
     public function transferCredit(Transfer $transfer)
     {
+        $transfer->setRequiredFields(array(
+            'amount',
+            'linkedAccount',
+            'merchantRefNum',
+        ));
+        $transfer->setOptionalFields(array(
+            'detail',
+            'dupCheck',
+        ));
+
         $request = new Request(array(
                'method' => Request::POST,
                'uri' => $this->prepareURI($this->creditPath),

--- a/source/Paysafe/AccountManagementService.php
+++ b/source/Paysafe/AccountManagementService.php
@@ -29,6 +29,26 @@ class AccountManagementService
         $this->client = $client;
     }
 
+    /**
+     * Monitor.
+     *
+     * @return bool true if successful
+     * @throws \Paysafe\PaysafeException
+     */
+    public function monitor()
+    {
+        $request = new Request(array(
+            'method' => Request::GET,
+            'uri' => 'accountmanagement/monitor'
+        ));
+
+        $response = $this->client->processRequest($request);
+        if (!isset($response['status'])) {
+            return false;
+        }
+        return ($response['status'] == 'READY');
+    }
+
     public function transferDebit(Transfer $transfer)
     {
         $request = new Request(array(

--- a/source/Paysafe/PaysafeApiClient.php
+++ b/source/Paysafe/PaysafeApiClient.php
@@ -183,6 +183,15 @@ class PaysafeApiClient
     }
 
     /**
+     * Account Management  service.
+     *
+     * @return \Paysafe\AccountManagementService
+     */
+    public function accountManagementService() {
+        return new AccountManagementService($this);
+    }
+
+    /**
 	 *
 	 * @param \Paysafe\Request $request
 	 * @return type

--- a/tests/paysafe/AccountManagement/TransferTest.php
+++ b/tests/paysafe/AccountManagement/TransferTest.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bjohnson
+ * Date: 8/30/17
+ * Time: 4:38 PM
+ */
+
+namespace Paysafe\AccountManagement;
+
+
+use function json_encode;
+use Paysafe\JSONObject;
+use Paysafe\Link;
+use Paysafe\Pageable;
+use Paysafe\PaysafeException;
+
+class TransferTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $t = new Transfer();
+        $this->assertThat($t, $this->isInstanceOf(Transfer::class));
+        $this->assertThat($t, $this->isInstanceOf(JSONObject::class));
+        $this->assertThat($t, $this->isInstanceOf(Pageable::class));
+    }
+
+    public function testGetPageableArrayKey()
+    {
+        $this->assertThat(Transfer::getPageableArrayKey(), $this->equalTo('transfers'));
+    }
+
+    public function testGetLink()
+    {
+        $foo_rel = 'foo';
+        $foo_href = 'http://foo.bar/bax';
+
+        $t = new Transfer([
+            'links' => [
+                ['rel' => $foo_rel, 'href' => $foo_href]
+            ]
+        ]);
+
+        $thelink = $t->getLink($foo_rel);
+        $this->assertThat($thelink, $this->isInstanceOf(Link::class));
+        $this->assertThat($thelink->rel, $this->equalTo($foo_rel));
+        $this->assertThat($thelink->href, $this->equalTo($foo_href));
+    }
+
+    public function testGetLinkUnknownLink()
+    {
+        $bad_rel = 'something_else';
+        $foo_rel = 'foo';
+        $foo_href = 'http://foo.bar/bax';
+
+        $t = new Transfer([
+            'links' => [
+                ['rel' => $foo_rel, 'href' => $foo_href]
+            ]
+        ]);
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionMessage('Link '. $bad_rel . ' not found in Transfer.');
+        $this->expectExceptionCode(0);
+        $t->getLink($bad_rel);
+    }
+
+    public function testGetLinkNoLinks()
+    {
+        $bad_rel = 'something_else';
+
+        $t = new Transfer();
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionMessage('Link '. $bad_rel . ' not found in Transfer.');
+        $this->expectExceptionCode(0);
+        $t->getLink($bad_rel);
+    }
+
+    public function testMissingRequiredFields()
+    {
+        $t = new Transfer();
+        $required_fields = ['amount', 'linkedAccount', 'merchantRefNum'];
+        $t->setRequiredFields($required_fields);
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Missing required properties: ' . join(', ', $required_fields));
+        $t->checkRequiredFields();
+    }
+
+    public function testConstructWithBogusProperty()
+    {
+        $t = new Transfer(['bogusproperty' => new \stdClass()]);
+        // when passing a property absent from the fieldTypes array to the constructor, the bogus property should be
+        // ignored
+        // we expect to receive an empty JSON object
+        $this->assertThat($t->toJson(), $this->equalTo('{}'));
+    }
+
+    public function testSetBogusProperty()
+    {
+        $t = new Transfer();
+
+        // when calling the setter on a property absent from the fieldTypes array, we expect an exception
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Invalid property bogusproperty for class Paysafe\AccountManagement\Transfer.');
+        $t->bogusproperty = new \stdClass();
+    }
+
+    public function testConstructWithValidProperty()
+    {
+        $t = new Transfer(['merchantRefNum' => 'foo']);
+        $this->assertThat($t->toJson(), $this->equalTo('{"merchantRefNum":"foo"}'));
+    }
+
+    public function testConstructWithMultipleValidProperties()
+    {
+        $t = new Transfer([
+            'merchantRefNum' => 'foo',
+            'amount' => 5
+        ]);
+        $this->assertThat($t->toJson(), $this->equalTo('{"merchantRefNum":"foo","amount":5}'));
+    }
+
+    public function testConstructWithInvalidValue()
+    {
+        $t_array = [
+            'merchantRefNum' => new \stdClass(),
+            'amount' => 5
+        ];
+        // merchantRefNum should be a string; object should throw an exception
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Invalid value for property merchantRefNum for class '
+            . 'Paysafe\AccountManagement\Transfer. String expected.');
+        new Transfer($t_array);
+    }
+
+    public function testSetInvalidValue()
+    {
+        $t = new Transfer();
+        // merchantRefNum should be a string; object should throw an exception
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Invalid value for property merchantRefNum for class '
+            . 'Paysafe\AccountManagement\Transfer. String expected.');
+        $t->merchantRefNum = new \stdClass();
+    }
+
+    public function testAllFieldsValidValues()
+    {
+        $id = 'id'; // string
+        $amount = 1; // int
+        $detail = 'detail'; //string
+        $dupCheck = true; // bool
+        $linkedAccount = 'linkedAccount'; // string
+        $merchantRefNum = 'merchantRefNum'; // string
+        $error = [ // \Paysafe\Error
+            'code' => 'code', // string
+            'message' => 'message', // 'string',
+            'details' => ['details1','details2'], // 'array:string',
+            'fieldErrors' => [[  // 'array:\Paysafe\FieldError',
+                'field' => 'field', // string
+                'error' => 'error', // string
+            ]],
+            'links' => [[ // 'array:\Paysafe\Link'
+                'rel' => 'rel', // 'string',
+                'href' => 'gopher://foo.bar', // 'url'
+            ]]
+        ];
+        $status = 'RECEIVED'; // enum
+        $links = [[ // 'array:\Paysafe\Link'
+            'rel' => 'rel', // 'string',
+            'href' => 'gopher://foo.bar', // 'url'
+        ]];
+
+        $t_array = [
+            'id' => $id,
+            'amount' => $amount,
+            'detail' => $detail,
+            'dupCheck' => $dupCheck,
+            'linkedAccount' => $linkedAccount,
+            'merchantRefNum' => $merchantRefNum,
+            'error' => $error,
+            'status' => $status,
+            'links' => $links,
+        ];
+
+        $t = new Transfer($t_array);
+
+        /*
+         * This may seem like a trivial test, but behind the scenes toJson triggers data validation. Bad data will
+         * result in an exception.
+         * Not only does this test ensure the proper operation of the json encoding in JSONObject, but it validates
+         * our understanding of the data requirements in Authorization
+         */
+        $this->assertThat($t->toJson(), $this->equalTo(json_encode($t_array)));
+    }
+}

--- a/tests/paysafe/AccountManagementServiceTest.php
+++ b/tests/paysafe/AccountManagementServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bjohnson
+ * Date: 8/29/17
+ * Time: 3:21 PM
+ */
+
+namespace Paysafe;
+
+/**
+ * Class AccountManagementServiceTest
+ * @package Paysafe
+ */
+class AccountManagementServiceTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject $mock_api_client */
+    private $mock_api_client;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->mock_api_client = $this->createMock(PaysafeApiClient::class);
+    }
+
+    public function testMonitor()
+    {
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(['status' => 'READY']); // the expected return for success
+
+        $ams = new AccountManagementService($this->mock_api_client);
+        $this->assertThat($ams->monitor(), $this->isTrue(), 'monitor did not return true as expected');
+    }
+
+    public function testMonitorNoStatus()
+    {
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn([]); // what happens if we get an empty array?
+
+        $ams = new AccountManagementService($this->mock_api_client);
+        // we *expect* false because anything other than status:READY is a fail
+        $this->assertThat($ams->monitor(), $this->isFalse(), 'monitor did not return false as expected');
+    }
+
+    public function testMonitorStatusNotReady()
+    {
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willReturn(['status' => 'some string other than READY']);
+
+        $ams = new AccountManagementService($this->mock_api_client);
+        // we *expect* false because anything other than status:READY is a fail
+        $this->assertThat($ams->monitor(), $this->isFalse(), 'monitor did not return false as expected');
+    }
+
+    public function testMonitorException()
+    {
+        $exception_msg = 'this is an expected test exception';
+        $exception_code = 123;
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->willThrowException(new PaysafeException($exception_msg, $exception_code));
+
+        // processRequest may throw an exception; monitor is expected to let that bubble up
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionMessage('this is an expected test exception');
+        $this->expectExceptionCode($exception_code);
+
+        $ams = new AccountManagementService($this->mock_api_client);
+        $ams->monitor();
+    }
+}


### PR DESCRIPTION
The goal of this PR is to add the capability to transfer funds among linked accounts to the paysafe SDK. As transfers are part of the Account Management API, this required adding Account Management to the SDK.

Highlights:
* Add incomplete implementation of AccountManagementService
    * The AccountManagementService added in this PR _only_ implements three methods:
        * `monitor` - verifies that account management api is active and responding
        * `transferDebit` - Move funds from the account identified in the API endpoint URI to the linked account in the body of the request
        * `transferCredit` - Move funds from the linked account in the body of the request to the account identified in the API endpoint URI.
* Add new class `Transfer` that extends `JSONObject`
    * this new class is used as the value object for new `transferDebit` and `transferCredit` methods
* Add PHPUnit tests for all of the above