### PR TITLE
Split refund

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -63,37 +63,40 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -101,20 +104,20 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -155,26 +158,26 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
-                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -200,24 +203,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
-                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.5 || ^7.0",
                 "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
@@ -247,37 +250,37 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -310,7 +313,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -377,16 +380,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -420,7 +423,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -563,16 +566,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.20",
+            "version": "5.7.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b"
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b1c822a68ae6577df38a59eb49b046712ec0f6a",
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +600,7 @@
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "symfony/yaml": "~2.1|~3.0|~4.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "3.0.2"
@@ -641,20 +644,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-22T07:42:55+00:00"
+            "time": "2017-11-14T14:50:51+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
-                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
@@ -700,7 +703,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1217,20 +1220,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.2",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063"
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/9752a30000a8ca9f4b34b5227d15d0101b96b063",
-                "reference": "9752a30000a8ca9f4b34b5227d15d0101b96b063",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0938408c4faa518d95230deabb5f595bf0de31b9",
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "require-dev": {
                 "symfony/console": "~2.8|~3.0"
@@ -1268,7 +1271,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02T22:05:06+00:00"
+            "time": "2017-11-10T18:26:04+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/source/Paysafe/CardPaymentService.php
+++ b/source/Paysafe/CardPaymentService.php
@@ -244,7 +244,8 @@ class CardPaymentService
         $refund->setRequiredFields(array('merchantRefNum'));
         $refund->setOptionalFields(array(
              'amount',
-             'dupCheck'
+             'dupCheck',
+             'splitpay',
         ));
 
         $request = new Request(array(

--- a/source/Paysafe/CardPayments/Refund.php
+++ b/source/Paysafe/CardPayments/Refund.php
@@ -33,6 +33,7 @@ namespace Paysafe\CardPayments;
  * @property \Paysafe\Error $error
  * @property \Paysafe\Link[] $links
  * @property string $settlementID
+ * @property \Paysafe\CardPayments\SplitPay[] $splitpay
  *
  */
 class Refund extends \Paysafe\JSONObject implements \Paysafe\Pageable
@@ -54,7 +55,8 @@ class Refund extends \Paysafe\JSONObject implements \Paysafe\Pageable
          'acquirerResponse' => '\Paysafe\CardPayments\AcquirerResponse',
          'error' => '\Paysafe\Error',
          'links' => 'array:\Paysafe\Link',
-         'settlementID' => 'string'
+         'settlementID' => 'string',
+         'splitpay' => 'array:\Paysafe\CardPayments\SplitPay',
     );
 
 }

--- a/tests/paysafe/CardPaymentServiceRefundTest.php
+++ b/tests/paysafe/CardPaymentServiceRefundTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bjohnson
+ * Date: 11/28/17
+ * Time: 1:52 PM
+ */
+
+namespace Paysafe;
+
+use Paysafe\CardPayments\Refund;
+
+/**
+ * Class CardPaymentServiceRefundTest
+ * This class provides coverage of the CardPaymentService::refund function
+ * @package Paysafe
+ */
+class CardPaymentServiceRefundTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject $mock_api_client */
+    private $mock_api_client;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->mock_api_client = $this->createMock(PaysafeApiClient::class);
+        $this->mock_api_client->method('getAccount')->willReturn('bogus_account_num');
+    }
+
+    /*
+     * This is a test to confirm that the CardPaymentService sets and checks the required settlementID field as
+     * expected.
+     *
+     * When settlementID is missing, an exception is thrown before any call to the api client
+     */
+    public function testRefundMissingRequiredSettlementId()
+    {
+        $cps = new CardPaymentService($this->mock_api_client);
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Missing required properties: settlementID');
+
+        $cps->refund(new Refund());
+    }
+
+    /*
+     * In this test we submit a valid value for settlementID so that we can get past that check and actually call
+     * processRequest. We make our mock call toJson to trigger the validation that would normally happen in the real
+     * client's processRequest. toJson should throw an exception since not all required params were passed.
+     */
+    public function testRefundMissingRequiredMerchantRefNum()
+    {
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->will($this->returnCallback(function (Request $param) {
+                return $param->body->toJson();
+            }));
+        $cps = new CardPaymentService($this->mock_api_client);
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Missing required properties: merchantRefNum');
+
+        $cps->refund(new Refund(['settlementID' => 'settlementID']));
+    }
+
+    /*
+     * This is a test to confirm that the CardPaymentService sets expected values for required/optional fields. If a
+     * parameter is set in the Refund obj, but not in the required or optional lists, it will be omitted from the
+     * JSON created by toJson. (toJson is called by processRequest in the api client).
+     *
+     * So, we'll make our mock api client call toJson, and confirm the output lacks the field that doesn't appear in
+     * required/optional.
+     */
+    public function testRefundInvalidField()
+    {
+        $this->mock_api_client
+            ->expects($this->once())
+            ->method('processRequest')
+            ->with($this->isInstanceOf(Request::class))
+            ->will($this->returnCallback(function (Request $param) {
+                return json_decode($param->body->toJson(), true);
+            }));
+        $cps = new CardPaymentService($this->mock_api_client);
+
+        $refund_param_array = [
+            'settlementID' => 'settlementID',
+            'merchantRefNum' => 'merchantRefNum',
+            'id' => 'id is a valid param, but not in required or optional list',
+        ];
+
+        $retval = $cps->refund(new Refund($refund_param_array));
+        $expected_params = $refund_param_array;
+        unset($expected_params['id']); // remove item not in required/optional list
+        // we also remove settlementID; refund() puts this value in URL and removes from body
+        unset($expected_params['settlementID']);
+        $this->assertThat($retval->toJson(), $this->equalTo(json_encode($expected_params)));
+    }
+}

--- a/tests/paysafe/CardPayments/RefundTest.php
+++ b/tests/paysafe/CardPayments/RefundTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: bjohnson
+ * Date: 11/28/17
+ * Time: 10:30 AM
+ */
+
+namespace Paysafe\CardPayments;
+
+
+use Paysafe\PaysafeException;
+
+class RefundTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $refund = new Refund();
+        $this->assertThat($refund, $this->isInstanceOf(Refund::class));
+    }
+
+    public function testGetPageableArrayKey()
+    {
+        $pak = Refund::getPageableArrayKey();
+        $this->assertThat($pak, $this->equalTo('refunds'));
+    }
+
+    public function testMissingRequiredFields()
+    {
+        $refund = new Refund();
+        $required_fields = ['settlementID', 'merchantRefNum'];
+        $refund->setRequiredFields($required_fields);
+
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage('Missing required properties: ' . join(', ', $required_fields));
+
+        $refund->checkRequiredFields();
+    }
+
+    public function testConstructWithBogusProperty()
+    {
+        $refund = new Refund(['bogusproperty' => new \stdClass()]);
+        // when passing a property absent from the fieldTypes array to the constructor, the bogus property should be
+        // ignored
+        // we expect to receive an empty JSON object
+        $this->assertThat($refund->toJson(), $this->equalTo('{}'));
+    }
+
+    public function testConstructWithValidProperty()
+    {
+        $refund = new Refund(['merchantRefNum' => 'foo']);
+        $this->assertThat($refund->toJson(), $this->equalTo('{"merchantRefNum":"foo"}'));
+    }
+
+    public function testConstructWithMultipleValidProperties()
+    {
+        $refund = new Refund([
+            'merchantRefNum' => 'foo',
+            'amount' => 5,
+        ]);
+        $this->assertThat($refund->toJson(), $this->equalTo('{"merchantRefNum":"foo","amount":5}'));
+    }
+
+    public function testConstructWithInvalidValue()
+    {
+        $refund_array = [
+            'merchantRefNum' => new \stdClass(),
+            'amount' => 5
+        ];
+        // merchantRefNum should be a string; object should throw an exception
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Invalid value for property merchantRefNum for class '
+            . Refund::class . '. String expected.');
+        $refund = new Refund($refund_array);
+    }
+
+    public function testSetInvalidValue()
+    {
+        $refund = new Refund();
+        // merchantRefNum should be a string; object should throw an exception
+        $this->expectException(PaysafeException::class);
+        $this->expectExceptionCode(0);
+        $this->expectExceptionMessage('Invalid value for property merchantRefNum for class '
+            . Refund::class . '. String expected.');
+        $refund->merchantRefNum = new \stdClass();
+    }
+
+    public function testAllFieldsValueValues()
+    {
+        $id = 'id'; // string
+        $merchantRefNum = 'merchantRefNum'; // string
+        $amount = 1; // int
+        $childAccountNum = 'childAccountNum'; // string
+        $dupCheck = true; // bool
+        $txnTime = 'txnTime'; // string
+        $status = 'status'; // string
+        $riskReasonCode = [1, 2]; // array:int
+        // $acquirerResponse should be an array acceptable to the Paysafe\CardPayments\AcquirerResponse constructor
+        $acquirerResponse = [
+            'code' => 'code', // string
+            'responseCode' => 'responseCode', // string
+            'avsCode' => 'avsCode', // string
+            'balanceResponse' => 'balanceResponse', // string
+            'batchNumber' => 'batchNumber', // string
+            'effectiveDate' => 'effectiveDate', // string
+            'financingType' => 'financingType', // string
+            'gracePeriod' => 'gracePeriod', // string
+            'plan' => 'plan', // string
+            'seqNumber' => 'seqNumber', // string
+            'term' => 'term', // string
+            'terminalId' => 'terminalId', // string
+            'responseId' => 'responseId', // string
+            'requestId' => 'requestId', // string
+            'description' => 'description', // string
+            'authCode' => 'authCode', // string
+            'txnDateTime' => 'txnDateTime', // string
+            'referenceNbr' => 'referenceNbr', // string
+            'responseReasonCode' => 'responseReasonCode', // string
+            'cvv2Result' => 'cvv2Result', // string
+            'mid' => 'mid', // string
+        ];
+        $error = [ // '\Paysafe\Error',
+            'code' => 'code',// 'string',
+            'message' => 'message', // 'string',
+            'details' => ['details1','details2'], // 'array:string',
+            'fieldErrors' => [[  // 'array:\Paysafe\FieldError',
+                'field' => 'field', // string
+                'error' => 'error', // string
+            ]],
+            'links' => [[ // 'array:\Paysafe\Link'
+                'rel' => 'rel', // 'string',
+                'href' => 'gopher://foo.ba', // 'url'
+            ]],
+        ];
+        $links = [[ // 'array:\Paysafe\Link',
+            'rel' => 'rel', // 'string',
+            'href' => 'gopher://foo.ba', // 'url'
+        ]];
+        $settlementID = 'settlementID'; // string
+
+        $refund_array = [
+            'id' => $id,
+            'merchantRefNum' => $merchantRefNum,
+            'amount' => $amount,
+            'childAccountNum' => $childAccountNum,
+            'dupCheck' => $dupCheck,
+            'txnTime' => $txnTime,
+            'status' => $status,
+            'riskReasonCode' => $riskReasonCode,
+            'acquirerResponse' => $acquirerResponse,
+            'error' => $error,
+            'links' => $links,
+            'settlementID' => $settlementID,
+        ];
+
+        $refund = new Refund($refund_array);
+        /*
+         * This may seem like a trivial test, but behind the scenes toJson triggers data validation. Bad data will
+         * result in an exception.
+         * Not only does this test ensure the proper operation of the json encoding in JSONObject, but it validates
+         * our understanding of the data requirements in Authorization
+         */
+        $this->assertThat($refund->toJson(), $this->equalTo(json_encode($refund_array)));
+    }
+}


### PR DESCRIPTION
This PR adds credit card "split refund" capability.

The changes are fairly simple:
* add splitpay element to the `Paysafe\CardPayments\Refund` object
* add splitpay to the list of optional fields for `Paysafe\CardPaymentService::refund`

I also included tests to fully exercise these changes. The tests are analogous to those already found in the split-pay branch, and can be run by issuing `composer test` from the project's root directory.